### PR TITLE
Fix webpack alias

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,6 +58,9 @@ module.exports = {
 
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],
+    alias: {
+      '~': path.resolve(__dirname, 'src'),
+    },
   },
 
   plugins: [


### PR DESCRIPTION
## Summary
- ensure webpack resolves `~` alias used in source code

## Testing
- `npm run type-check` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6863927ab910832da8e6081aa7f90894