### PR TITLE
Fix ESLint config rule duplication

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -43,7 +43,6 @@ module.exports = {
     '@typescript-eslint/consistent-type-imports': 'error',
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     '@typescript-eslint/no-explicit-any': 'warn',
-    '@typescript-eslint/consistent-type-imports': 'off',
     'import/extensions': [
       'error',
       'ignorePackages',


### PR DESCRIPTION
## Summary
- remove duplicate `@typescript-eslint/consistent-type-imports` rule from ESLint config

## Testing
- `npm run lint:fix` *(fails: ESLint couldn't find config)*
- `npm run type-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68652bcc13f0832d84cf819f006435c5